### PR TITLE
Remove assert that verifies if tables were marked

### DIFF
--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -162,9 +162,6 @@ class PostgresTarget(luigi.Target):
                 (self.update_id, self.table,
                  datetime.datetime.now()))
 
-        # make sure update is properly marked
-        assert self.exists(connection)
-
     def exists(self, connection=None):
         if connection is None:
             connection = self.connect()


### PR DESCRIPTION
A summary of this would be that having multiple workers and multiple
insert/select on the same table causes a lot of issues. Please refer
yourself to the issue below to have a better idea.

fixes glossier#2